### PR TITLE
Expand condensed schedule with execution details

### DIFF
--- a/docs/CondensedSchedule.md
+++ b/docs/CondensedSchedule.md
@@ -78,3 +78,32 @@ This schedule covers tasks 1–20 described in the project brief. At least three
 - **Retrospective & lessons learned:** Run a cross-functional retro to capture process improvements and tooling gaps for future releases.
 - **Roadmap alignment:** Use outcomes from the schedule to update the quarterly roadmap, focusing on enhancements, model retraining cadence, and plugin ecosystem growth.
 - **Operational hand-off:** Transition runbooks, dashboards, and on-call rotations to the operations/support organization with sign-offs on SLAs and escalation paths.
+
+## Proceeding Next: Day 0 Kickoff Playbook
+- **Kickoff session agenda (90 minutes):**
+  1. Reconfirm objectives, success metrics, and non-negotiable scope.
+  2. Walk through the 14-day plan, highlighting critical dependencies and integration checkpoints.
+  3. Review risk radar items, assign owners, and capture new issues raised during the meeting.
+  4. Lock communication cadences, escalation paths, and decision-making authority (who signs off what and when).
+  5. Validate tooling readiness (CI/CD, observability, shared documentation spaces) and align on how to request access help.
+- **Backlog burn-down setup:** Ensure each squad has sprint boards seeded with Day 1–3 stories, acceptance criteria, and Definition of Done checklists; load cross-team dependencies into the shared dependency tracker.
+- **Decision & risk registers:** Stand up a shared workspace (e.g., Confluence/Notion) with templates for logging decisions, open questions, and mitigation status to maintain transparency across squads.
+- **Engineering enablement checklist:** Confirm feature flag framework, secrets management policies, coding standards, and branching strategy are documented and acknowledged by all contributors before development begins.
+- **Stakeholder alignment:** Circulate a kickoff digest summarizing deliverables, meeting cadence, and escalation triggers to executive sponsors and adjacent teams (support, finance, legal).
+
+## Workstream Scorecard & Reporting Cadence
+- **Weekly scorecard owners:**
+  - *Platform & Infrastructure:* Track environment uptime, pipeline success rates, and mean time to recover from failed deployments.
+  - *Core Services:* Report on API contract completion, service reliability (error budgets), and defect escape rates from testing.
+  - *Experience & Enablement:* Measure UI completion percentage, accessibility audit findings, and localization coverage.
+  - *Data & Intelligence:* Monitor ETL job success, data quality thresholds, and predictive model accuracy (MAPE or RMSE).
+  - *Quality & Compliance:* Provide daily test coverage metrics, open severity-1/2 defects, and compliance checkpoint status.
+- **Scorecard distribution:** Publish the consolidated scorecard every Monday morning ahead of the steering committee, and post daily deltas in the shared status channel to spotlight emerging risks.
+- **Escalation triggers:** Define quantitative thresholds (e.g., more than two consecutive failed deploys, regression suite coverage drops below 85%, accessibility blocker severity ≥2) that automatically prompt a war-room session within 4 hours.
+
+## Operational Tooling Snapshot
+- **Project tracking:** Jira or Azure Boards with swimlanes per squad and cross-team dependency swimlane for visibility.
+- **Documentation hub:** Centralized workspace with templates for APIs, runbooks, and post-incident reviews.
+- **Communication stack:** Dedicated Slack/Teams channels for each squad, one #daily-standup summary channel, and an executive readout channel for twice-weekly updates.
+- **Observability dashboards:** Pre-built Grafana/Kibana views pinned for deployment health, service latencies, and error budgets; alerts routed through PagerDuty with escalation policies defined during the kickoff.
+- **Quality automation:** CI jobs configured to run static analysis, unit/integration suites, and security scans with gating rules agreed in the engineering enablement checklist.

--- a/docs/CondensedSchedule.md
+++ b/docs/CondensedSchedule.md
@@ -1,0 +1,80 @@
+# 14-Day Condensed Delivery Schedule
+
+This schedule covers tasks 1–20 described in the project brief. At least three major tasks are planned per day with parallel execution where feasible.
+
+## Planning Assumptions
+- Four cross-functional squads (Platform, Core Services, Experience, and Data/ML) are available and can swarm when a task requires extra capacity.
+- Shared enabling work (e.g., observability, testing frameworks) is front-loaded so dependent teams can operate autonomously by mid-schedule.
+- Daily checkpoints ensure hand-offs (API contracts, schema changes, feature flags) are signed off before downstream teams begin their work the following morning.
+- Buffer for unexpected findings is absorbed by staggering testing and hardening across multiple days rather than at the end.
+
+| Day | Tasks | Dependencies / Parallelism Notes |
+| --- | ----- | -------------------------------- |
+| **1** | 1. Set up Git repositories, CI/CD pipelines, and provision dev/staging/prod environments with a secrets manager. 2. Provision data warehouse/data lake and define initial schemas. 3. Configure Elasticsearch indices and caching infrastructure. 19. Establish initial observability foundations (metrics/logs stack). | Infrastructure tasks run in parallel. Observability tooling installed alongside core environments to instrument subsequent services. |
+| **2** | 2. Finalize relational database model and schema governance. 4. Begin Authentication & RBAC service scaffolding. 10. Design ETL pipelines and streaming backbone (Kafka/RabbitMQ). | Auth & ETL design leverage Day 1 infrastructure and schema definitions. Workstreams proceed concurrently with interface contracts agreed upfront. |
+| **3** | 5. Develop User & Vehicle CRUD with VIN validation and caching. 12. Implement Notification service (SMS/email providers). 4. Integrate Authentication & RBAC with CRUD workflows. | CRUD depends on Authentication groundwork and caching from Day 1. Notification service wired to Auth for secure messaging; activities executed in parallel sub-teams. |
+| **4** | 6. Create Scheduling service with appointment state machine and notifications. 7. Implement WorkOrder service with state transitions. 12. Extend notification templates and hooks for Scheduling/WorkOrder events. | Requires CRUD, Auth, and Notification components from previous days. Teams coordinate shared APIs while developing in parallel. |
+| **5** | 8. Build Inventory/Parts service with reservation logic. 9. Develop Supplier service & purchase order workflow. 10. Expand ETL coverage for inventory and supplier events. | Inventory provides data model consumed by Supplier service; close collaboration enables parallel builds. ETL updates capture new domain events. |
+| **6** | 11. Integrate payment gateway with HMAC-signed webhooks and idempotency keys. 14. Start plugin registration framework foundation. 8/9. Harden Inventory & Supplier services (validation, error handling). | Payment flows require User and WorkOrder services; plugin framework leverages shared service architecture. Service hardening happens concurrently. |
+| **7** | 13. Begin Super Admin dashboard (garage/provider management). 15. Kick off localization (Arabic RTL / English LTR) and WCAG audit. 17. Implement pseudonymization and data-retention processes (data services). | Dashboard consumes completed services. Localization begins with shared UI components. Data governance tasks run alongside UI work. |
+| **8** | 13. Continue Super Admin dashboard (marketplace modules, toggles). 16. Launch unit & integration test suites across services. 18. Start training predictive model for parts demand using ETL outputs. | Testing spans previously built services; model training leverages inventory & supplier data. Activities run in parallel with distinct teams. |
+| **9** | 16. Conduct performance & security testing and remediate findings. 17. Finalize pseudonymization/data-retention jobs. 19. Configure observability dashboards and SLO-based alerts. | Testing feedback loops into security/data-governance work. Observability tuned with metrics from active services. |
+| **10** | 15. Finalize localization & WCAG 2.1 AA compliance fixes. 14. Complete plugin framework developer experience. 18. Refine predictive model and validate against holdout sets. 16. Run regression test sweep after fixes. | Localization depends on completed dashboard UI; plugin work finalizes documentation and tooling. Regression confirms stability ahead of deployments. |
+| **11** | 20. Deploy to staging via canary/blue-green strategy and run smoke tests. 16. Address staging issues identified in smoke/regression tests. 12. Finalize localized notification templates and fallbacks. | Staging deployment hinges on prior regression success. Localization of notifications aligned with Day 10 outcomes. |
+| **12** | 20. Promote to production with monitored rollout. 19. Finalize observability dashboards and alert routing. 10. Operationalize ETL pipelines (scheduling, monitoring). 18. Integrate predictive model inference into production services. | Production rollout coordinated with observability readiness; ETL and model integration ensure live data availability. |
+| **13** | 13. Polish Super Admin dashboard (modules, subscriptions, feature toggles). 14. Monitor plugin registration and partner onboarding. 17. Verify data-retention execution and audit trails. 19. Confirm SLO alerts firing under load tests. | Post-deployment refinements executed in parallel by product, platform, and compliance teams. |
+| **14** | 16. Perform final integration, performance, security, and accessibility test pass; resolve critical issues. 18. Validate predictive model performance in production and establish monitoring thresholds. 20. Execute final smoke tests and cut release sign-off. 15. Complete accessibility audit sign-off. | Final assurance gate before project closure; parallel squads handle testing, data science validation, and accessibility certification. |
+
+## Daily Execution Notes
+- **Day 1:** Platform squad provisions infrastructure while Data squad configures storage foundations; caching/Elasticsearch owners instrument logging hooks to unlock later observability work.
+- **Day 2:** Core Services squad kicks off Authentication while Data squad finalizes schemas; Integration architects document API/security contracts for ETL and Auth before close of day.
+- **Day 3:** CRUD team consumes Auth contracts delivered on Day 2; Notification templates are stubbed in parallel, with shared secrets managed via the secrets manager established on Day 1.
+- **Day 4:** Scheduling and WorkOrder squads share domain events and leverage Notification hooks; API versioning agreed so downstream services can subscribe without blocking.
+- **Day 5:** Inventory and Supplier squads pair on shared data model; ETL engineers add new topics/streams to capture state changes for analytics and ML.
+- **Day 6:** Payment integration validates webhook security in a staging sandbox; Plugin framework defines registration lifecycle, aligning extension points with Inventory/Supplier enhancements.
+- **Day 7:** Experience squad scaffolds Super Admin UI while Localization engineers audit component library; Compliance partners lead pseudonymization design reviews.
+- **Day 8:** Automated tests run in CI nightly; Data/ML squad begins feature engineering for demand prediction using fresh ETL feeds.
+- **Day 9:** Performance/security testing drives backlog of fixes; Observability engineers configure SLOs based on load scenarios exercised by QA.
+- **Day 10:** Accessibility specialists sign off on localized UI changes; Plugin framework documentation handed to partner enablement team; Data/ML iterates on model accuracy metrics.
+- **Day 11:** Release managers execute staged canary; issues triaged through daily war room; Localization team finalizes multi-language notification fallbacks.
+- **Day 12:** Production rollout proceeds with heightened monitoring; Model inference service toggled on with gradual traffic ramp; ETL ownership transitions to operations runbook.
+- **Day 13:** Admin dashboard polished with metrics and feature toggles; Plugin onboarding monitored via analytics dashboards; Data retention jobs dry-run to validate compliance evidence.
+- **Day 14:** Final assurance gate validates performance/security/accessibility before sign-off; Predictive model KPIs reviewed for go/no-go; Release retrospective documents lessons learned.
+
+## Parallel Workstream Overview
+- **Platform & Infrastructure:** Leads tasks 1, 3, 19, and 20, ensuring environments, observability, and deployment strategies support other teams.
+- **Core Services:** Owns tasks 4–9 and 11, coordinating service-to-service contracts and domain workflows.
+- **Experience & Enablement:** Delivers tasks 12–15, focusing on end-user experiences, localization, and extensibility.
+- **Data & Intelligence:** Handles tasks 2, 10, 17, and 18, providing schemas, ETL, governance, and predictive insights.
+- **Quality & Compliance:** Drives task 16 with continuous testing, feeding results back to all squads for remediation.
+
+## Additional Notes
+- Dependencies are met on or before the day a task begins; contingency buffers handled via cross-day overlap and daily checkpoints.
+- Observability (task 19) and testing (task 16) are iterative, with milestones reflected on the days above.
+- Canary/blue-green deployments are rehearsed in lower environments on Days 9–10 to derisk the Day 11 cutover.
+
+## Immediate Next Steps
+1. **Confirm staffing and ownership.** Validate that every task in the schedule has a directly accountable lead (product, engineering, QA, data) and supporting contributors identified.
+2. **Baseline backlog readiness.** Ensure epics and stories for the first three days are refined, estimated, and accepted into the sprint board; schedule just-in-time grooming for subsequent days.
+3. **Finalize environment access.** Distribute credentials for CI/CD, cloud environments, secrets manager, and analytics tooling so squads can start on Day 1 without blockers.
+4. **Establish communication cadence.** Book daily cross-squad stand-ups, end-of-day check-ins, and a twice-weekly steering review with executive stakeholders.
+5. **Set up progress tracking.** Align on burndown dashboards, risk registers, and dependency trackers that will be updated at each checkpoint.
+
+## Risk Radar and Mitigations
+- **Environment provisioning delays:** Pre-stage infrastructure automation scripts and secure cloud quotas; assign a dedicated platform engineer on call for rapid triage.
+- **Cross-squad contract churn:** Require signed API/schema contracts before development starts; maintain a shared specification repository with versioning and approval workflow.
+- **Third-party integrations (payments, messaging):** Schedule early sandbox validation (Days 6–7) and have fallback providers or manual procedures documented.
+- **Testing fatigue in condensed timeline:** Rotate QA responsibilities across squads and enforce automated regression suites from Day 8 onward to reduce manual overhead.
+- **Localization & accessibility surprises:** Engage accessibility specialists from Day 7 and allocate buffer stories for remediation discovered during audits.
+
+## Governance & Reporting
+- **Daily stand-up (30 min):** Representatives from each squad share progress, risks, and cross-team requests.
+- **End-of-day checkpoint (15 min async):** Update shared status doc with completed tasks, outstanding issues, and ETA adjustments.
+- **Steering committee (Tue/Fri):** Review milestone health, budget impacts, and approve scope changes or contingency plans.
+- **Risk & decision log:** Capture mitigation owners and due dates; review during steering sessions.
+
+## Post-Day-14 Follow Through
+- **Hypercare window (Week 3):** Keep core squads on pager rotation for production monitoring, ticket triage, and fast patching.
+- **Retrospective & lessons learned:** Run a cross-functional retro to capture process improvements and tooling gaps for future releases.
+- **Roadmap alignment:** Use outcomes from the schedule to update the quarterly roadmap, focusing on enhancements, model retraining cadence, and plugin ecosystem growth.
+- **Operational hand-off:** Transition runbooks, dashboards, and on-call rotations to the operations/support organization with sign-offs on SLAs and escalation paths.

--- a/docs/CondensedSchedule.md
+++ b/docs/CondensedSchedule.md
@@ -107,3 +107,49 @@ This schedule covers tasks 1–20 described in the project brief. At least three
 - **Communication stack:** Dedicated Slack/Teams channels for each squad, one #daily-standup summary channel, and an executive readout channel for twice-weekly updates.
 - **Observability dashboards:** Pre-built Grafana/Kibana views pinned for deployment health, service latencies, and error budgets; alerts routed through PagerDuty with escalation policies defined during the kickoff.
 - **Quality automation:** CI jobs configured to run static analysis, unit/integration suites, and security scans with gating rules agreed in the engineering enablement checklist.
+
+## Day 0 Runbook Timeline
+- **T-48 hours:** Circulate pre-read packet (schedule, risk radar, team roster) and confirm attendance for kickoff; ensure all tooling accounts are provisioned.
+- **T-24 hours:** Hold dependency alignment sync between squad leads to validate API contracts and data schema readiness; document open issues with owners and due dates.
+- **T-12 hours:** Platform team completes final environment smoke tests; Quality team verifies CI pipelines execute baseline checks without regressions.
+- **T-3 hours:** Share kickoff agenda reminder, distribute dial-in details, and confirm note taker plus action-item tracker ownership.
+- **Kickoff (T0):** Execute agenda outlined above, capture decisions, and update shared workspace in real time.
+- **T+2 hours:** Publish kickoff summary, distribute action items, and update scorecards with Day 1 targets.
+- **T+6 hours:** Squad leads confirm Day 1 sprint boards are groomed and blockers resolved; Program manager reviews risk register for any escalations.
+- **T+12 hours:** Send final “all systems go” status to stakeholders, highlighting any constraints being monitored during Day 1 start.
+
+## Squad Readiness Checklists
+- **Platform & Infrastructure:**
+  - Infrastructure-as-code repositories reviewed and passing lint/security scans.
+  - Secrets rotation schedule defined; break-glass procedure rehearsed.
+  - Monitoring probes configured for core environments and queued services.
+- **Core Services:**
+  - API contracts documented with versioning strategy and mocking assets available.
+  - Service templates include observability hooks (metrics, traces) and security middleware by default.
+  - Backlog contains integration test scenarios mapped to cross-service interactions.
+- **Experience & Enablement:**
+  - Design system updated with localization tokens and RTL/LTR toggles.
+  - Accessibility checklist integrated into Definition of Done for UI stories.
+  - Content team prepped with translation glossary and review workflows.
+- **Data & Intelligence:**
+  - Data quality rules and acceptance thresholds established for each ETL pipeline.
+  - Feature store conventions agreed (naming, versioning, retention) and documented.
+  - Model monitoring instrumentation outlined (drift metrics, alert thresholds).
+- **Quality & Compliance:**
+  - Test environments mapped to deployment stages with data refresh cadence defined.
+  - Security scanning tools configured with alert routing to responsible engineers.
+  - Compliance evidence templates stored in documentation hub for easy updates.
+
+## Integration Rehearsal Plan
+1. **Service contract dry-run:** Within 48 hours of Day 1, run mock API calls between core services using contract tests to validate request/response fidelity.
+2. **Deployment drill:** Execute a non-production blue-green cutover rehearsal to verify pipeline steps, rollback strategy, and observability signals.
+3. **Notification workflow simulation:** Trigger end-to-end messaging flows (SMS/email) across staging systems to validate localization and template fallbacks.
+4. **Data pipeline validation:** Process synthetic data through ETL pipelines and confirm arrival in the warehouse, downstream model training, and dashboard ingestion.
+5. **Access review:** Confirm RBAC assignments across tooling (Jira, repos, CI/CD, cloud) match least-privilege expectations prior to Day 1.
+
+## Contingency Playbooks
+- **Infrastructure blocker:** Activate backup environment plan using pre-provisioned IaC templates; escalate to cloud vendor support with critical SLA.
+- **Third-party outage (payments, notifications):** Switch to pre-approved fallback provider or enable manual operations procedure, logging all transactions for later reconciliation.
+- **Regression suite failure:** Invoke war-room within one hour, triage to responsible squad, and enforce fix-forward or rollback decision within the same business day.
+- **Data quality breach:** Pause downstream model training and analytics consumption, trigger data governance response plan, and communicate timeline for remediation.
+- **Localization defects discovered late:** Enable feature flag to limit exposure to impacted locale while remediation stories are expedited.


### PR DESCRIPTION
## Summary
- document a 14-day plan that sequences tasks 1-20 with at least three tasks per day
- capture dependencies and parallel execution notes for each day
- record planning assumptions, daily execution notes, and workstream ownership to guide parallel delivery
- add immediate next steps, risk mitigation, governance cadence, and post-day-14 follow-through guidance to clarify "what next"

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68c6df3dee18832aa9ca7562de4b72d6