### PR TITLE
Add tool management module sprint plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 ### 🔹 7. Tool Management
 - Shared and per-garage tools
 - Tool linking to service steps
-- 📄 See `Tasks/ToolManagementModulePlan/` for sprint breakdown
+- 📄 See `Tasks/ToolManagementModulePlan/` for three-sprint roadmap and deliverables
 
 ### 🔹 8. Job Cards & Task Assignment
 - Job creation from services  

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@
 ## 🔜 Next Modules in Order
 
 ### 🔹 7. Tool Management
-- Shared and per-garage tools  
+- Shared and per-garage tools
 - Tool linking to service steps
+- 📄 See `Tasks/ToolManagementModulePlan/` for sprint breakdown
 
 ### 🔹 8. Job Cards & Task Assignment
 - Job creation from services  

--- a/Tasks/ToolManagementModulePlan/Sprint1.md
+++ b/Tasks/ToolManagementModulePlan/Sprint1.md
@@ -1,0 +1,80 @@
+# 🧰 Sprint 1: Tool Registry Foundations
+
+## 🎯 Sprint Goal
+Establish the core Tool Management data model and APIs so garages can catalog tools, classify them, and manage basic availability across branches.
+
+---
+
+## ✅ Tasks Breakdown
+
+### 1. Create Core Tool Entities
+- **Data Model:**
+  - `Tool`: `Id`, `Name`, `Description`, `ToolType`, `Brand`, `Manufacturer`, `SerialNumber`, `PurchaseDate`, `WarrantyExpiry`, `IsCalibrated`, `CalibrationDueDate`, `IsGlobal`, `GarageId?`, `CreatedBy`, `CreatedAt`, `UpdatedAt`, `IsActive`.
+  - `ToolTag`: `Id`, `Name` (global lookup managed by SaaS admins).
+  - `ToolToolTag`: join table for tool-to-tag assignment.
+- **Why:** Provides structured storage for critical tool metadata, enabling filtering and governance for global vs. garage-only tools.
+
+### 2. Branch-Level Availability Tracking
+- **Data Model:**
+  - `ToolAvailability`: `Id`, `ToolId`, `GarageId`, `BranchId?`, `Quantity`, `Status` (Available, InUse, UnderMaintenance), `ConditionNotes`, `LastServicedAt`.
+- **API:**
+  - `POST /api/tools/{id}/availability` to set initial availability.
+  - `PUT /api/tools/{id}/availability/{availabilityId}` to update status or quantity.
+  - `GET /api/tools/{id}/availability` to list branch allocations.
+- **Why:** Allows each garage to control where tools are located and whether they are usable, preparing for job card reservations later.
+
+### 3. CRUD Endpoints & Validation
+- **Endpoints:**
+  - `POST /api/tools`
+  - `PUT /api/tools/{id}`
+  - `GET /api/tools`
+  - `GET /api/tools/{id}`
+  - `DELETE /api/tools/{id}` (soft delete via `IsActive` flag)
+- **Validation:**
+  - Enforce unique `Name + GarageId` pairs for local tools.
+  - Prevent deleting tools that still have availability records unless flagged inactive.
+- **Why:** Enables admins to manage the full lifecycle of tool records securely.
+
+### 4. Tag & Classification Management
+- **Endpoints:**
+  - `GET /api/tool-tags`
+  - `POST /api/tool-tags`
+- **Frontend:**
+  - Multi-select tagging component in the tool creation form.
+  - Filter tools by tag and tool type in listing screen.
+- **Why:** Tags unlock quick filtering (e.g., Diagnostic, Safety) and align with future automation for service matching.
+
+### 5. Audit Trail & Activity Log Hooks
+- **Tasks:**
+  - Emit domain events on tool create/update/delete.
+  - Store `CreatedBy`, `UpdatedBy`, `UpdatedAt`.
+  - Log availability changes (status and quantity) with actor info.
+- **Why:** Maintains traceability for compliance and operational reviews.
+
+---
+
+## 📌 Acceptance Criteria
+- [ ] Tools can be created with full metadata and tags.
+- [ ] Tool availability entries exist per garage/branch with status tracking.
+- [ ] CRUD operations respect soft delete rules and validation constraints.
+- [ ] Tag lookup endpoints support admin management and UI filtering.
+- [ ] Activity logs or domain events record tool and availability changes.
+
+---
+
+## ⏱️ Estimated Effort
+| Area | Time |
+|------|------|
+| Backend (entities, handlers, logging) | 2.5 days |
+| API & validation | 1.5 days |
+| Frontend (forms, lists, tagging) | 1.5 days |
+| QA/UAT | 0.5 day |
+
+**Total:** ~6 dev days
+
+---
+
+## ✅ Sprint Outcome
+- Central tool registry ready for production garages.
+- Visibility into where tools are located and if they are usable.
+- Foundation for future reservation and maintenance workflows.

--- a/Tasks/ToolManagementModulePlan/Sprint2.md
+++ b/Tasks/ToolManagementModulePlan/Sprint2.md
@@ -1,0 +1,80 @@
+# 🔧 Sprint 2: Maintenance & Reservation Workflows
+
+## 🎯 Sprint Goal
+Layer operational workflows on top of the tool registry so garages can reserve tools for jobs, track maintenance/calibration, and enforce availability rules during scheduling.
+
+---
+
+## ✅ Tasks Breakdown
+
+### 1. Tool Reservation Engine
+- **Data Model:**
+  - `ToolReservation`: `Id`, `ToolId`, `JobCardId`, `ServiceStepId?`, `ReservedFrom`, `ReservedTo`, `ReservedQuantity`, `Status` (Pending, Confirmed, Released, Cancelled), `ReservedBy`, `CreatedAt`.
+- **Logic:**
+  - Prevent overlapping reservations beyond available quantity.
+  - Auto-release reservations when job step completes or is cancelled.
+- **API:**
+  - `POST /api/tools/{id}/reservations`
+  - `PUT /api/tool-reservations/{id}/release`
+  - `GET /api/tools/{id}/reservations?range=...`
+- **Why:** Ensures tools are not double-booked and supports the upcoming job card flow.
+
+### 2. Maintenance & Calibration Tracking
+- **Data Model:**
+  - `ToolMaintenanceLog`: `Id`, `ToolId`, `PerformedAt`, `PerformedBy`, `Type` (Calibration, Repair, Inspection), `Notes`, `NextDueDate`, `AttachmentUrls`.
+- **API:**
+  - `POST /api/tools/{id}/maintenance`
+  - `GET /api/tools/{id}/maintenance`
+- **Automation:**
+  - Scheduled job to flag tools with overdue calibration.
+  - Notification hooks for Garage Admin and Supervisor roles.
+- **Why:** Keeps tools compliant and safe, aligning with real-world regulatory needs.
+
+### 3. Scheduling Integration Hooks
+- **Tasks:**
+  - Extend service scheduling logic to check tool availability.
+  - Provide conflict response (e.g., `ToolUnavailable` error code with alternatives).
+  - Offer override option for Garage Admin (forces reservation with warning).
+- **Frontend:**
+  - During booking, show availability summary for required tools.
+- **Why:** Connects the tool module to service/job planning workflows.
+
+### 4. Alerts & Notifications
+- **Tasks:**
+  - Create notification templates for reservation confirmations, releases, and maintenance due alerts.
+  - Integrate with existing notification service (email/app push).
+- **Why:** Keeps technicians and supervisors informed about tool readiness.
+
+### 5. Reporting Snapshot
+- **Endpoints:**
+  - `GET /api/tools/dashboard` returning counts: Available, In Use, Under Maintenance, Overdue Calibration.
+  - `GET /api/tools/{id}/usage-summary` for utilization metrics.
+- **Why:** Provides quick insights for operations teams without needing the full reporting module yet.
+
+---
+
+## 📌 Acceptance Criteria
+- [ ] Tool reservations enforce quantity and time window rules.
+- [ ] Job scheduling checks tool availability and handles conflicts.
+- [ ] Maintenance logs capture history with next due dates.
+- [ ] Notifications are triggered for reservations and maintenance reminders.
+- [ ] Dashboard endpoints expose utilization metrics.
+
+---
+
+## ⏱️ Estimated Effort
+| Area | Time |
+|------|------|
+| Backend (reservations, maintenance, sched integration) | 3 days |
+| Frontend (booking conflict UI, maintenance log views) | 2 days |
+| Notifications & scheduled jobs | 1 day |
+| QA/UAT | 0.5 day |
+
+**Total:** ~6.5 dev days
+
+---
+
+## ✅ Sprint Outcome
+- Tools can be reserved confidently for upcoming jobs.
+- Maintenance cadence is tracked and visible.
+- Schedulers and supervisors receive timely alerts, reducing downtime.

--- a/Tasks/ToolManagementModulePlan/Sprint3.md
+++ b/Tasks/ToolManagementModulePlan/Sprint3.md
@@ -1,0 +1,87 @@
+# 🚀 Sprint 3: Intelligent Tool Operations
+
+## 🎯 Sprint Goal
+Enhance the Tool Management module with intelligent suggestions, technician mobile workflows, and telemetry signals so garages can proactively manage tool readiness and optimize utilization across locations.
+
+---
+
+## ✅ Tasks Breakdown
+
+### 1. Service & Inventory Intelligence
+- **Integrations:**
+  - Link tool metadata with spare part catalog to recommend required tools alongside parts in service templates.
+  - Surface suggested tools during job planning based on historical service-tool associations.
+- **Backend:**
+  - Extend `ServiceStep` configuration to reference recommended tools with priority and quantity hints.
+  - Batch job to analyze historical reservations and suggest updates to recommended tool mappings.
+- **Frontend:**
+  - Update service configuration UI to manage recommended tools.
+  - Highlight suggested tools in job planning and allow one-click reservation creation.
+- **Why:** Provides planners with contextual guidance, reducing missed tool requirements and improving preparedness.
+
+### 2. Technician Mobile Checkout & Scanning
+- **Mobile UX:**
+  - Add tool checkout/check-in flow to technician mobile app (QR/barcode scan or manual lookup).
+  - Display reservation queue and allow technicians to mark tools as picked up, in use, or returned.
+- **APIs:**
+  - `POST /api/tools/{id}/checkouts` to begin technician usage session.
+  - `PUT /api/tool-checkouts/{id}/return` to close the session and update availability/condition.
+- **Backend Logic:**
+  - Tie checkout status into reservation lifecycle, auto-updating `ToolAvailability` and triggering maintenance checks if condition issues are reported.
+- **Why:** Ensures real-time visibility into tool usage and minimizes lost or misplaced equipment.
+
+### 3. Telemetry & IoT Hooks
+- **Ingestion:**
+  - Create webhook endpoint to receive usage hours and status alerts from connected tool sensors.
+  - Normalize events (`usage_recorded`, `fault_detected`, `calibration_trigger`).
+- **Processing:**
+  - Update maintenance scheduling service to consider telemetry-driven triggers.
+  - Store telemetry history for trend analysis and audit.
+- **Notifications:**
+  - Send urgent alerts for fault detections to supervisors and maintenance leads.
+- **Why:** Enables predictive maintenance and reduces unplanned downtime.
+
+### 4. Advanced Analytics & Insights
+- **Dashboards:**
+  - Expand reporting endpoint to include utilization trends, mean time between maintenance, and cross-branch sharing opportunities.
+- **Data Warehouse:**
+  - Publish tool usage/reservation facts to analytics pipeline (e.g., BigQuery, Snowflake) for company-wide insights.
+- **UI:**
+  - Provide operations dashboard widgets for top under-utilized tools and upcoming maintenance windows.
+- **Why:** Gives leadership actionable data to optimize capital expenditure and tool rotation.
+
+### 5. Rollout & Change Management
+- **Documentation:**
+  - Produce quick start guide for technicians on mobile workflows.
+  - Update admin playbooks with telemetry setup steps and recommended KPIs.
+- **Training & Pilots:**
+  - Run pilot with two garages, gather feedback, and iterate on UX friction points.
+- **Why:** Supports smooth adoption and drives measurable value from new capabilities.
+
+---
+
+## 📌 Acceptance Criteria
+- [ ] Service configuration shows recommended tools and planners can apply them during job creation.
+- [ ] Technicians can scan tools to check them in/out, updating reservations and availability in real time.
+- [ ] Telemetry events adjust maintenance schedules and trigger alerts without manual intervention.
+- [ ] Analytics endpoints expose trend metrics and feed the broader BI pipeline.
+- [ ] Training materials and pilot feedback loop are completed ahead of general rollout.
+
+---
+
+## ⏱️ Estimated Effort
+| Area | Time |
+|------|------|
+| Intelligence integrations & analytics | 2.5 days |
+| Mobile workflows & APIs | 2 days |
+| Telemetry ingestion & automation | 1.5 days |
+| Training, documentation, pilots | 1 day |
+
+**Total:** ~7 dev days
+
+---
+
+## ✅ Sprint Outcome
+- Intelligent tool recommendations reduce planning errors and expedite reservations.
+- Technicians have real-time mobile workflows for tracking tool usage.
+- Telemetry-driven maintenance keeps tools safe and available while providing deep operational insight.

--- a/Tasks/ToolManagementModulePlan/Summery.md
+++ b/Tasks/ToolManagementModulePlan/Summery.md
@@ -1,0 +1,45 @@
+# 🛠️ Tool Management Module — Delivery Plan
+
+## 🎯 Epic Objective
+Equip garages with a centralized tool registry, availability tracking, maintenance workflows, and scheduling integration so technicians always have the right equipment when they need it.
+
+---
+
+## 🚀 Sprint 1: Tool Registry Foundations
+- Establish core entities (`Tool`, `ToolTag`, `ToolAvailability`).
+- Provide CRUD APIs with validation and audit logging.
+- Introduce tagging, filtering, and branch-level availability management.
+- Outcome: Garages can register tools, classify them, and know where each tool is located.
+
+## 🔧 Sprint 2: Maintenance & Reservation Workflows
+- Add reservation engine to prevent double-booking of tools during job planning.
+- Track maintenance/calibration logs with reminders and notifications.
+- Integrate tool availability checks into service scheduling flows.
+- Outcome: Tool readiness is enforced operationally with alerts and dashboards.
+
+## 📈 Future Sprint (Preview)
+- Integrate with inventory/spare parts to suggest tools alongside services.
+- Add technician mobile app interfaces for checkout/check-in scanning.
+- Enable IoT/telemetry hooks for tool usage monitoring and automated maintenance tickets.
+
+---
+
+## 📋 Cross-Cutting Considerations
+| Topic | Notes |
+|-------|-------|
+| **Security & Permissions** | Restrict tool CRUD to SaaS Admin or Garage Admin. Supervisors can manage availability only. |
+| **Soft Delete & Audit** | Use `IsActive` flag, maintain audit trails for compliance. |
+| **Performance** | Index by `GarageId`, `ToolType`, `IsActive` for fast listings across large fleets. |
+| **Integrations** | Expose events (`tool.created`, `tool.reservation.created`) for analytics and downstream systems. |
+| **UI/UX** | Provide dashboards highlighting overdue calibration, under-utilized tools, and conflict alerts. |
+
+---
+
+## ⏱️ Total Estimated Effort
+| Sprint | Estimate |
+|--------|----------|
+| Sprint 1 | ~6 dev days |
+| Sprint 2 | ~6.5 dev days |
+| Future Sprint | ~5 dev days (tentative) |
+
+**Overall:** ~17.5 dev days for the first two sprints plus an optional future sprint.

--- a/Tasks/ToolManagementModulePlan/Summery.md
+++ b/Tasks/ToolManagementModulePlan/Summery.md
@@ -17,10 +17,11 @@ Equip garages with a centralized tool registry, availability tracking, maintenan
 - Integrate tool availability checks into service scheduling flows.
 - Outcome: Tool readiness is enforced operationally with alerts and dashboards.
 
-## 📈 Future Sprint (Preview)
-- Integrate with inventory/spare parts to suggest tools alongside services.
-- Add technician mobile app interfaces for checkout/check-in scanning.
-- Enable IoT/telemetry hooks for tool usage monitoring and automated maintenance tickets.
+## 🚀 Sprint 3: Intelligent Tool Operations
+- Recommend tools alongside service templates and historical usage.
+- Provide technician mobile scanning workflows tied to reservations and availability.
+- Ingest telemetry data to trigger maintenance and deliver advanced analytics insights.
+- Outcome: Data-driven automation keeps tools ready, visible, and optimized across the network.
 
 ---
 
@@ -40,6 +41,6 @@ Equip garages with a centralized tool registry, availability tracking, maintenan
 |--------|----------|
 | Sprint 1 | ~6 dev days |
 | Sprint 2 | ~6.5 dev days |
-| Future Sprint | ~5 dev days (tentative) |
+| Sprint 3 | ~7 dev days |
 
-**Overall:** ~17.5 dev days for the first two sprints plus an optional future sprint.
+**Overall:** ~19.5 dev days across the first three sprints.


### PR DESCRIPTION
## Summary
- add a two-sprint implementation plan for the upcoming Tool Management module
- document sprint goals, tasks, and acceptance criteria for core registry and reservation workflows
- update the module roadmap to reference the new planning documents

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68effe354c3c832a9564efab66caa560